### PR TITLE
Issue 2 - Yarn License Read Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ This hook ensures that there are no comments that demand immediate action. Curre
 
 ## Changelog
 
+*v0.0.4*
+
+Fix `yarn-licenses` file reading issue for large yarn.lock files
+
+Trim option segments for `explicit-packages` command line argument
+
 *v0.0.3*
 
 Add hook for checking node packages against a whitelist (`yarn-licenses`)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='luminopa_pre_commit_hooks',
     description='Some custom pre-commit-hooks used by Luminopia',
     url='https://github.com/luminopia/pre-commit-hooks',
-    version='0.0.3',
+    version='0.0.4',
 
     author='Alex Wendland',
     author_email='alex@luminopia.com',


### PR DESCRIPTION
Yarn Licenses - Use temporary file strategy for reading raw license output

- Read output of yarn licenses command to a temporary file to avoid limitations in command output line lengths when piping
- Use absolute path for current working directory of yarn lock file
- Strip extra whitespace from explicit package options. Allows for more graceful formatting in yml files.
- Update version to v0.0.4